### PR TITLE
Fix height of DayPicker control

### DIFF
--- a/src/Fritz.ResourceManagement.Web/wwwroot/css/Schedule.css
+++ b/src/Fritz.ResourceManagement.Web/wwwroot/css/Schedule.css
@@ -3,10 +3,9 @@
 }
 
 .monthpicker {
-	min-height: 234px;
 	display: grid;
 	grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-	grid-template-rows: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+	grid-template-rows: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
 	grid-column-gap: 0px;
 	grid-row-gap: 0px;
 }


### PR DESCRIPTION
Here's my fix for the variable height with the DayPicker control in issue #11 

It was a pretty easy fix. We only needed to add an extra row to the CSS grid to the grid-template-rows property.

This is my first time contributing so I hope I did this correctly.