### PR TITLE
Fix: DayView appointments are positioned correctly

### DIFF
--- a/src/Fritz.ResourceManagement.Web/Components/Availability.razor
+++ b/src/Fritz.ResourceManagement.Web/Components/Availability.razor
@@ -30,6 +30,7 @@
 		</div>
 
 	</div>
+</div>
 
 <div id="MySchedule" style="display: inline-block">
 	<h3>My Schedule</h3>

--- a/src/Fritz.ResourceManagement.Web/Components/DayView.razor
+++ b/src/Fritz.ResourceManagement.Web/Components/DayView.razor
@@ -1,30 +1,36 @@
 ﻿@using Fritz.ResourceManagement.Domain
 @inject Data.ScheduleState MyScheduleState
 @inject Data.ExpandedSchedule ExpandedSchedule
-<div class="dayview">
-	@{
-		var currentTime = new DateTimeOffset(2000, 1, 1, 8, 0, 0, TimeSpan.Zero);
-	}
-	@for (var i = 0; i < 24; i++)
-	{
-
-		<span class="grid">
-			@if (i % 2 == 0)
+	<div class="dayview">
+		@{
+			var currentTime = DayViewStart;
+		}
+		@for (var i = 0; i < 24; i++)
+		{
+			if (i % 2 == 0)
 			{
-				<text>@currentTime.ToString("h:mm tt")</text>
+				<span class="grid" style="grid-column: 1;">
+					<text>@currentTime.ToString("h:mm tt")</text>
+				</span>
 				currentTime = currentTime.AddHours(1);
 			}
-		</span>
-	}
+			else
+			{
+				<span class="grid" style="grid-column: 2;"></span>
+			}
+		}
 
-	@foreach (var item in ExpandedSchedule.TimeSlots.Where(s => s.StartDateTime.Date == SelectedDate.Date))
-	{
-		<span class="scheduleItem" style="top: calc(1.5em * @(item.StartDateTime.Hour-8)); height: calc(1.5em * @(item.Duration.Hours)))">
-			@item.Name  - @item.StartDateTime.ToShortTimeString()
-		</span>
-	}
+		@foreach (var item in ExpandedSchedule.TimeSlots.Where(s => s.StartDateTime.Date == SelectedDate.Date))
+		{
+			if (DisplayScheduleItem(item.StartDateTime, item.EndDateTime))
+			{
+				<span class="scheduleItem" style="grid-row-start: @ScheduleItemStartRow(item.StartDateTime); top: @ScheduleItemMinutesPosition(item.StartDateTime); height: @ScheduleItemRowHeight(item.StartDateTime, item.EndDateTime);">
+					@item.Name  - @item.StartDateTime.ToShortTimeString()
+				</span>
+			}
+		}
 
-</div>
+	</div>
 
 @*
 Today is <span>@SelectedDate</span>
@@ -42,6 +48,16 @@ Today is <span>@SelectedDate</span>
 		get { return MyScheduleState.Schedule; }
 	}
 
+	DateTime DayViewStart
+	{
+		get { return MyScheduleState.SelectedDate.AddHours(8); }
+	}
+
+	DateTime DayViewEnd
+	{
+		get { return MyScheduleState.SelectedDate.AddHours(20); }
+	}
+
 	protected override void OnInit()
 	{
 
@@ -57,6 +73,53 @@ Today is <span>@SelectedDate</span>
 	{
 		this.StateHasChanged();
 		base.OnParametersSet();
+	}
+
+	bool DisplayScheduleItem(DateTime start, DateTime end)
+	{
+		if (start >= DayViewEnd || end <= DayViewStart) { return false; }
+		return true;
+	}
+
+	int ScheduleItemStartRow(DateTime start)
+	{
+		if (start.Hour <= DayViewStart.Hour)
+		{
+			return 1;
+		}
+
+		return (start.Hour - DayViewStart.Hour) + 1;
+	}
+
+	string ScheduleItemMinutesPosition(DateTime start)
+	{
+		double top = 0D;
+		if (start > DayViewStart && start.Minute > 0)
+		{
+			top = 0.025 * start.Minute;
+		}
+		return (top > 0) ? $"{top}em" : "0";
+	}
+
+	string ScheduleItemRowHeight(DateTime start, DateTime end)
+	{
+		double height;
+		double totalMinutes;
+
+		if (end >= DayViewEnd)
+		{
+			end = DayViewEnd;
+		}
+
+		if (start < DayViewStart)
+		{
+			start = DayViewStart;
+		}
+
+		totalMinutes = end.Subtract(start).TotalMinutes;
+		height = 0.063 * (end.Hour - start.Hour); // Adjust for row gaps
+		height += 0.025 * totalMinutes;
+		return (height > 0) ? $"{height}em" : "0;";
 	}
 
 }

--- a/src/Fritz.ResourceManagement.Web/Components/DayView.razor
+++ b/src/Fritz.ResourceManagement.Web/Components/DayView.razor
@@ -3,25 +3,31 @@
 @inject Data.ExpandedSchedule ExpandedSchedule
 <div class="dayview">
 	@{
-		var currentTime = new DateTimeOffset(2000, 1, 1, 8, 0, 0, TimeSpan.Zero);
+		var currentTime = DayViewStart;
 	}
 	@for (var i = 0; i < 24; i++)
 	{
-
-		<span class="grid">
-			@if (i % 2 == 0)
-			{
+		if (i % 2 == 0)
+		{
+			<span class="grid" style="grid-column: 1;">
 				<text>@currentTime.ToString("h:mm tt")</text>
-				currentTime = currentTime.AddHours(1);
-			}
-		</span>
+			</span>
+			currentTime = currentTime.AddHours(1);
+		}
+		else
+		{
+			<span class="grid" style="grid-column: 2;"></span>
+		}
 	}
 
 	@foreach (var item in ExpandedSchedule.TimeSlots.Where(s => s.StartDateTime.Date == SelectedDate.Date))
 	{
-		<span class="scheduleItem" style="top: calc(1.5em * @(item.StartDateTime.Hour-8)); height: calc(1.5em * @(item.Duration.Hours)))">
-			@item.Name  - @item.StartDateTime.ToShortTimeString()
-		</span>
+		if (DisplayScheduleItem(item.StartDateTime, item.EndDateTime))
+		{
+			<span class="scheduleItem" style="grid-row-start: @ScheduleItemStartRow(item.StartDateTime); top: @ScheduleItemMinutesPosition(item.StartDateTime); height: @ScheduleItemRowHeight(item.StartDateTime, item.EndDateTime);">
+				@item.Name  - @item.StartDateTime.ToShortTimeString()
+			</span>
+		}
 	}
 
 </div>
@@ -42,6 +48,16 @@ Today is <span>@SelectedDate</span>
 		get { return MyScheduleState.Schedule; }
 	}
 
+	DateTime DayViewStart
+	{
+		get { return MyScheduleState.SelectedDate.AddHours(8); }
+	}
+
+	DateTime DayViewEnd
+	{
+		get { return MyScheduleState.SelectedDate.AddHours(20); }
+	}
+
 	protected override void OnInit()
 	{
 
@@ -57,6 +73,53 @@ Today is <span>@SelectedDate</span>
 	{
 		this.StateHasChanged();
 		base.OnParametersSet();
+	}
+
+	bool DisplayScheduleItem(DateTime start, DateTime end)
+	{
+		if (start >= DayViewEnd || end <= DayViewStart) { return false; }
+		return true;
+	}
+
+	int ScheduleItemStartRow(DateTime start)
+	{
+		if (start.Hour <= DayViewStart.Hour)
+		{
+			return 1;
+		}
+
+		return (start.Hour - DayViewStart.Hour) + 1;
+	}
+
+	string ScheduleItemMinutesPosition(DateTime start)
+	{
+		double top = 0D;
+		if (start > DayViewStart && start.Minute > 0)
+		{
+			top = 0.025 * start.Minute;
+		}
+		return (top > 0) ? $"{top}em" : "0";
+	}
+
+	string ScheduleItemRowHeight(DateTime start, DateTime end)
+	{
+		double height;
+		double totalMinutes;
+
+		if (end >= DayViewEnd)
+		{
+			end = DayViewEnd;
+		}
+
+		if (start < DayViewStart)
+		{
+			start = DayViewStart;
+		}
+
+		totalMinutes = end.Subtract(start).TotalMinutes;
+		height = 0.063 * (end.Hour - start.Hour); // Adjust for row gaps
+		height += 0.025 * totalMinutes;
+		return (height > 0) ? $"{height}em" : "0;";
 	}
 
 }

--- a/src/Fritz.ResourceManagement.Web/wwwroot/css/Schedule.css
+++ b/src/Fritz.ResourceManagement.Web/wwwroot/css/Schedule.css
@@ -76,9 +76,8 @@
 		position: absolute;
 		border: 1px solid navy;
 		background-color: papayawhip;
-		grid-column: 2 / auto;
+		grid-column: 2;
 		left: 10px;
 		right: 10px;
-		height: 3em;
 	}
 


### PR DESCRIPTION
I have applied an Issue #16 fix for the positioning issues of appointments on the DayView component. This PR made a few changes to the DayView component.

First, I needed a way to know the time span that the schedule is visually showing to the user. I added a _DayViewStart_ and _DayViewEnd_ property to the component. Both are currently hardcoded to 8 AM and 8 PM respectively.

Second, I slightly changed how the DayView outputs the CSS grid in HTML. In order to use the _grid-row-start_ CSS property for a schedule item, I needed to make sure the grid cells underneath did not move when a item was positioned over it. To do this, every cell in the grid needed a _grid-column_ property. This would make calculating the starting minute of a schedule item much easier.

_And then_ I added the following methods to determine if and where to position a schedule item:

**DisplayScheduleItem** determines if a schedule item should be drawn on the DayView.
**ScheduleItemStartRow**  decides which grid row to start a schedule item.
**ScheduleItemMinutesPosition** calculates the top position in a grid row for a schedule item to the minute.
**ScheduleItemRowHeight** calculates the height of a schedule item based on its duration and adjusts for the grid row gaps.

All the calculations are currently hardcoded in ems. It may not be as responsive as I would like, but it works. We can make it better later.