### PR TITLE
DayView appointments are positioned correctly and DayView appointment…

### DIFF
--- a/src/Fritz.ResourceManagement.Web/Components/Availability.razor
+++ b/src/Fritz.ResourceManagement.Web/Components/Availability.razor
@@ -30,6 +30,7 @@
 		</div>
 
 	</div>
+</div>
 
 <div id="MySchedule" style="display: inline-block">
 	<h3>My Schedule</h3>

--- a/src/Fritz.ResourceManagement.Web/Components/DayView.razor
+++ b/src/Fritz.ResourceManagement.Web/Components/DayView.razor
@@ -1,27 +1,34 @@
 ﻿@using Fritz.ResourceManagement.Domain
 @inject Data.ScheduleState MyScheduleState
 @inject Data.ExpandedSchedule ExpandedSchedule
+
 <div class="dayview">
 	@{
 		var currentTime = new DateTimeOffset(2000, 1, 1, 8, 0, 0, TimeSpan.Zero);
 	}
 	@for (var i = 0; i < 24; i++)
 	{
-
-		<span class="grid">
-			@if (i % 2 == 0)
-			{
+		if (i % 2 == 0)
+		{
+			<span class="grid" style="grid-column: 1;">
 				<text>@currentTime.ToString("h:mm tt")</text>
-				currentTime = currentTime.AddHours(1);
-			}
-		</span>
+				@{ currentTime = currentTime.AddHours(1); }
+			</span>
+		}
+		else
+		{
+			<span class="grid" style="grid-column: 2;"></span>
+		}
 	}
 
 	@foreach (var item in ExpandedSchedule.TimeSlots.Where(s => s.StartDateTime.Date == SelectedDate.Date))
 	{
-		<span class="scheduleItem" style="top: calc(1.5em * @(item.StartDateTime.Hour-8)); height: calc(1.5em * @(item.Duration.Hours)))">
-			@item.Name  - @item.StartDateTime.ToShortTimeString()
-		</span>
+		if (DisplayItem(item.StartDateTime, item.EndDateTime))
+		{
+			<span class="scheduleItem @ItemBorderStyle(item.StartDateTime, item.EndDateTime)" style="grid-row-start: @ItemStartRow(item.StartDateTime); top: @ItemTopPosition(item.StartDateTime); height: @ItemRowHeight(item.StartDateTime, item.EndDateTime);">
+				@item.Name  - @item.StartDateTime.ToShortTimeString()
+			</span>
+		}
 	}
 
 </div>
@@ -42,6 +49,16 @@ Today is <span>@SelectedDate</span>
 		get { return MyScheduleState.Schedule; }
 	}
 
+	DateTime DayViewStart
+	{
+		get { return MyScheduleState.SelectedDate.AddHours(8); }
+	}
+
+	DateTime DayViewEnd
+	{
+		get { return MyScheduleState.SelectedDate.AddHours(20); }
+	}
+
 	protected override void OnInit()
 	{
 
@@ -59,4 +76,72 @@ Today is <span>@SelectedDate</span>
 		base.OnParametersSet();
 	}
 
+	bool DisplayItem(DateTime start, DateTime end)
+	{
+		if (start >= DayViewEnd || end <= DayViewStart) { return false; }
+		return true;
+	}
+
+	string ItemBorderStyle(DateTime start, DateTime end)
+	{
+		string top = "starts-before";
+		string bottom = "ends-after";
+
+		return String.Format("{0} {1}",
+			(start < DayViewStart) ? top : "",
+			(end > DayViewEnd) ? bottom : "");
+	}
+
+	int ItemStartRow(DateTime start)
+	{
+		if (start.Hour <= DayViewStart.Hour)
+		{
+			return 1;
+		}
+
+		return (start.Hour - DayViewStart.Hour) + 1;
+	}
+
+	string ItemTopPosition(DateTime start)
+	{
+		double top = 0D;
+
+		if (start < DayViewStart)
+		{
+			return "-0.050em";
+		}
+
+		if (start > DayViewStart && start.Minute > 0)
+		{
+			top = 0.025 * start.Minute;
+		}
+		return (top > 0) ? $"{top}em" : "0";
+	}
+
+	string ItemRowHeight(DateTime start, DateTime end)
+	{
+		double height = 0D;
+		double totalMinutes;
+
+		if (end >= DayViewEnd)
+		{
+			end = DayViewEnd;
+		}
+
+		if (start < DayViewStart)
+		{
+			start = DayViewStart;
+			height += 0.050; // Add 2 extra minutes for negative top position
+		}
+
+
+		totalMinutes = end.Subtract(start).TotalMinutes;
+		height += 0.025 * totalMinutes; // 1 minute = 1.25em / 60 = 0.025em
+
+		/* Adjust for row gaps, 1px = 0.063em at base 16px size 
+		 * according to http://pxtoem.com/ */
+		height += 0.063 * (end.Hour - start.Hour);
+
+		return (height > 0) ? $"{height}em" : "0;";
+	}
 }

--- a/src/Fritz.ResourceManagement.Web/wwwroot/css/Schedule.css
+++ b/src/Fritz.ResourceManagement.Web/wwwroot/css/Schedule.css
@@ -82,3 +82,10 @@
 		height: 3em;
 	}
 
+	.dayview .starts-before {
+		border-top: 0;
+	}
+
+	.dayview .ends-after {
+		border-bottom: 0;
+	}


### PR DESCRIPTION
I have applied an Issue #16 fix for the positioning issues of appointments on the DayView component. This PR made a few changes to the DayView component.

First, I needed a way to know the time span that the schedule is visually showing to the user. I added a _DayViewStart_ and _DayViewEnd_ property to the component. Both are currently hardcoded to 8 AM and 8 PM respectively.

Second, I slightly changed how the DayView outputs the CSS grid in HTML. In order to use the _grid-row-start_ CSS property for a schedule item, I needed to make sure the grid cells underneath did not move when a item was positioned over it. To do this, every cell in the grid needed a _grid-column_ property. This would make calculating the starting minute of a schedule item much easier.

Third, the starting position of a schedule item is calculated to the minute and displayed accordingly. The height of the box is now calculated by the duration in minutes and row gaps are accounted for. A schedule item is not allowed to have a height greater than the DayView.

Finally, I have added a graphical representation when a schedule item goes beyond the time span of the DayView. Items that start before 8 AM have an open border and a closed border when starting at 8 AM. Items that end after 8 PM and at 8 PM behave the same way.

![dayview1](https://user-images.githubusercontent.com/1839652/60624157-886b8c80-9db2-11e9-85a4-404842533319.jpg)

![dayview2](https://user-images.githubusercontent.com/1839652/60624189-a0431080-9db2-11e9-9b45-56615d8b21dd.jpg)

All the calculations are currently hardcoded in ems. It may not be as responsive as I would like, but it works. We can make it better later.