### PR TITLE
#56 - Refactoring Blazor code into ViewModels

### DIFF
--- a/src/Fritz.ResourceManagement.WebClient/Pages/Availability.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/Availability.razor
@@ -33,9 +33,7 @@
 
 			<DayPicker />
 
-			<DayView DayViewStart="DateTime.Today.AddHours(8)" 
-							 DayViewEnd="DateTime.Today.AddHours(20)"
-							 MyScheduleState="Model.MyScheduleState"/>
+			<DayView DayViewStart="Model.DayViewStart" DayViewEnd="Model.DayViewEnd" MyScheduleState="Model.MyScheduleState"/>
 
 		</div>
 

--- a/src/Fritz.ResourceManagement.WebClient/Pages/Availability.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/Availability.razor
@@ -1,29 +1,26 @@
-@using Fritz.ResourceManagement.Domain
-@inject System.Security.Claims.ClaimsPrincipal CurrentUser
-@inject Data.ScheduleState MyScheduleState
-@inject HttpClient HttpClient
+@inject ViewModels.AvailabilityViewModel Model
 
 	<div class="row">
 		<div id="Availability" class="col-md-8" style="vertical-align: top; ">
 
-			<h3>Set the availability for @CurrentUser.Identity.Name</h3>
+			<h3>Set the availability for @Model.CurrentUser.Identity.Name</h3>
 
 			<div>
 
 				<div style="display: inline-block" class="form-group">
 					<h4>Scheduled Appointments</h4>
 
-					<input class="form-control" type="text" name="Name" @bind="NewScheduleItem.Name" placeholder="Name of the Appointment" />
-					<input class="form-control" type="datetime" name="StartTime" @bind="NewScheduleItem.StartDateTime" placeholder="Start Date and Time" />
-					<input class="form-control" type="datetime" name="EndTime" @bind="NewScheduleItem.EndDateTime" placeholder="End Date and Time" />
-					<button class="btn btn-primary" @onclick="() => AddNewScheduleItem()">Add New Schedule Item</button>
+					<input class="form-control" type="text" name="Name" @bind="Model.NewScheduleItem.Name" placeholder="Name of the Appointment" />
+					<input class="form-control" type="datetime" name="StartTime" @bind="Model.NewScheduleItem.StartDateTime" placeholder="Start Date and Time" />
+					<input class="form-control" type="datetime" name="EndTime" @bind="Model.NewScheduleItem.EndDateTime" placeholder="End Date and Time" />
+					<button class="btn btn-primary" @onclick="() => Model.AddNewScheduleItem()">Add New Schedule Item</button>
 
 				</div>
 
 				<div style="display: inline-block" class="form-group">
 					<h4>Create a Recurring Schedule</h4>
 
-					<RecurrenceDataEntry Schedule="NewRecurringSchedule" OnSave="AddNewRecurringSchedule" />
+					<RecurrenceDataEntry Schedule="Model.NewRecurringSchedule" OnSave="Model.AddNewRecurringSchedule" />
 
 				</div>
 
@@ -38,98 +35,14 @@
 
 			<DayView DayViewStart="DateTime.Today.AddHours(8)" 
 							 DayViewEnd="DateTime.Today.AddHours(20)"
-							 MyScheduleState="MyScheduleState"/>
+							 MyScheduleState="Model.MyScheduleState"/>
 
 		</div>
 
 	</div>
 
-
 @code {
 
 	// Cheer 500 electrichavoc 07/06/19
-
-	Schedule MySchedule { get; set; } = null;
-
-	DateTime SelectedDate { get; set; } = DateTime.Today;
-
-	DateTime ThisMonth { get { return new DateTime(SelectedDate.Year, SelectedDate.Month, 1); } }
-
-
-	ScheduleItem NewScheduleItem;
-	RecurringSchedule NewRecurringSchedule;
-
-	protected override async Task OnInitAsync()
-	{
-		ResetScheduleItem();
-		MySchedule = await GetMyAvailability();
-
-		MyScheduleState.SelectDate(SelectedDate);
-		MyScheduleState.Schedule = MySchedule;
-		MyScheduleState.ExpandSchedule();
-
-	}
-
-
-	async Task<Schedule> GetMyAvailability()
-	{
-
-		return await HttpClient.GetJsonAsync<Schedule>($"schedule/{MyScheduleState.ScheduleId}");
-
-	}
-
-	async Task AddNewScheduleItem()
-	{
-
-		// Cheer 200 ultramark 07/06/19
-		// Cheer 100 TheMichaelJolley 07/06/19
-
-		NewScheduleItem.Status = ScheduleStatus.NotAvailable;
-		NewScheduleItem.ScheduleId = MySchedule.Id;
-		MySchedule.ScheduleItems.Add(NewScheduleItem);
-
-		await HttpClient.PutJsonAsync($"schedule/{MySchedule.Id}", MySchedule);
-
-		MyScheduleState.ScheduleUpdated();
-
-		ResetScheduleItem();
-
-	}
-
-	async Task AddNewRecurringSchedule()
-	{
-
-		// Cheer 2000 organicIT 23/06/19 
-
-		NewRecurringSchedule.Status = ScheduleStatus.NotAvailable;
-		NewRecurringSchedule.ScheduleId = MySchedule.Id;
-		MySchedule.RecurringSchedules.Add(NewRecurringSchedule);
-
-		await HttpClient.PutJsonAsync($"schedule/{MySchedule.Id}", MySchedule);
-
-		MyScheduleState.ScheduleUpdated();
-
-		ResetScheduleItem();
-
-	}
-
-	void ResetScheduleItem()
-	{
-
-		NewScheduleItem = new ScheduleItem();
-		NewScheduleItem.StartDateTime = DateTime.Today;
-		NewScheduleItem.EndDateTime = DateTime.Today.AddDays(1);
-
-		NewRecurringSchedule = new RecurringSchedule();
-		NewRecurringSchedule.MinStartDateTime = DateTime.Today;
-		NewRecurringSchedule.MaxEndDateTime = DateTime.Today.AddDays(7);
-
-
-	}
-
-	protected override void OnParametersSet()
-	{
-		base.OnParametersSet();
-	}
-
+	protected override async Task OnInitAsync() => await Model.OnInitAsync();
 }

--- a/src/Fritz.ResourceManagement.WebClient/Pages/DayPicker.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/DayPicker.razor
@@ -20,16 +20,9 @@
 
 	@for (var i = 1; i <= Model.LastDayOfMonth; i++)
 	{
-
-		var thisDay = new DateTime(Model.SelectedDate.Year, Model.SelectedDate.Month, i);
-		var today = (thisDay.Date == DateTime.Today.Date) ?
-			"today" : null;
-		var todayTitle = (string.IsNullOrEmpty(today)) ? null : "Today!";
-		var hasAppt = Model.MyScheduleState.TimeSlots.Any(ts => ts.StartDateTime.Date == thisDay.Date) ?
-			"appt" : null;
-		var selected = (thisDay == Model.SelectedDate) ? "active" : null;
-
-		<span class="@today @hasAppt @selected day" title="@todayTitle" @onclick="() => Model.MyScheduleState.SelectDate(thisDay)">@i</span>
+		// TODO: Simon G - Should be able to replace this loop with a ForEach over a new method Model.GetDaysOfMonthToRender() that returns List<DayOfMonthDisplayInfo> - Should wait for app UI running again to dev test before attempting.
+		var displayInfo = this.Model.DisplayDayOfMonth(i);
+		<span class="@displayInfo.Today @displayInfo.HasAppointment @displayInfo.IsSelected day" title="@displayInfo.Title" @onclick="() => Model.MyScheduleState.SelectDate(displayInfo.ThisDay)">@i</span>
 	}
 
 </div>

--- a/src/Fritz.ResourceManagement.WebClient/Pages/DayPicker.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/DayPicker.razor
@@ -1,10 +1,9 @@
-﻿@using Fritz.ResourceManagement.Domain
-@inject Data.ScheduleState MyScheduleState
+﻿@inject ViewModels.DayPickerViewModel Model
 <div class="monthpicker">
 
-	<button id="prevMonth" @onclick="PrevMonth">&lt;</button>
-	<div id="name">@SelectedDate.ToString("MMMM yyyy")</div>
-	<button id="nextMonth" @onclick="NextMonth">&gt;</button>
+	<button id="prevMonth" @onclick="Model.PrevMonth">&lt;</button>
+	<div id="name">@Model.SelectedDate.ToString("MMMM yyyy")</div>
+	<button id="nextMonth" @onclick="Model.NextMonth">&gt;</button>
 
 	<span class="dow">Su</span>
 	<span class="dow">M</span>
@@ -14,75 +13,26 @@
 	<span class="dow">F</span>
 	<span class="dow">Sa</span>
 
-	@for (var i = 0; i < FirstDayOfMonthDoW; i++)
+	@for (var i = 0; i < Model.FirstDayOfMonthDoW; i++)
 	{
 		<span></span>
 	}
 
-	@for (var i = 1; i <= LastDayOfMonth; i++)
+	@for (var i = 1; i <= Model.LastDayOfMonth; i++)
 	{
 
-		var thisDay = new DateTime(SelectedDate.Year, SelectedDate.Month, i);
+		var thisDay = new DateTime(Model.SelectedDate.Year, Model.SelectedDate.Month, i);
 		var today = (thisDay.Date == DateTime.Today.Date) ?
 			"today" : null;
 		var todayTitle = (string.IsNullOrEmpty(today)) ? null : "Today!";
-		var hasAppt = MyScheduleState.TimeSlots.Any(ts => ts.StartDateTime.Date == thisDay.Date) ?
+		var hasAppt = Model.MyScheduleState.TimeSlots.Any(ts => ts.StartDateTime.Date == thisDay.Date) ?
 			"appt" : null;
-		var selected = (thisDay == SelectedDate) ? "active" : null;
+		var selected = (thisDay == Model.SelectedDate) ? "active" : null;
 
-		<span class="@today @hasAppt @selected day" title="@todayTitle" @onclick="() => MyScheduleState.SelectDate(thisDay)">@i</span>
+		<span class="@today @hasAppt @selected day" title="@todayTitle" @onclick="() => Model.MyScheduleState.SelectDate(thisDay)">@i</span>
 	}
 
 </div>
-<button id="gotoToday" @onclick="GotoToday">Today</button>
+<button id="gotoToday" @onclick="Model.GotoToday">Today</button>
 
-<span>Selected Date is: @SelectedDate.ToShortDateString()</span>
-
-@code {
-
-	DateTime SelectedDate {
-		get { return MyScheduleState.SelectedDate; }
-		set { MyScheduleState.SelectDate(value); }
-	}
-
-	Schedule MySchedule {
-		get { return MyScheduleState.Schedule; }
-	}
-
-	int FirstDayOfMonthDoW
-	{
-		get
-		{
-
-			var first = new DateTime(SelectedDate.Year, SelectedDate.Month, 1);
-			return (int)first.DayOfWeek;
-
-		}
-	}
-
-	int LastDayOfMonth
-	{
-		get
-		{
-			return new DateTime(SelectedDate.Year, SelectedDate.Month, 1).AddMonths(1).AddDays(-1).Day;
-		}
-	}
-
-	void PrevMonth()
-	{
-		SelectedDate = SelectedDate.AddMonths(-1);
-		SelectedDate = new DateTime(SelectedDate.Year, SelectedDate.Month, 1);
-	}
-
-	void NextMonth()
-	{
-		SelectedDate = SelectedDate.AddMonths(1);
-		SelectedDate = new DateTime(SelectedDate.Year, SelectedDate.Month, 1);
-	}
-
-	void GotoToday()
-	{
-		SelectedDate = DateTime.Today;
-	}
-
-}
+<span>Selected Date is: @Model.SelectedDate.ToShortDateString()</span>

--- a/src/Fritz.ResourceManagement.WebClient/Pages/DayView.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/DayView.razor
@@ -1,103 +1,81 @@
-﻿@using Fritz.ResourceManagement.Domain
+﻿@inject ViewModels.DayViewViewModel Model
 
-@{ 
+<div class="dayview" style="grid-template-columns: 4.3em repeat(@Model.DayCount,1fr); grid-template-rows: repeat(@Model.HoursPerDay, 1.5em);">
+	@{
 
-	var currentTime = DayViewStart;
-	var hoursPerDay = DayViewEnd.Subtract(DayViewStart).Hours;
-
-}
-
-	<div class="dayview" style="grid-template-columns: 4.3em repeat(@DayCount,1fr); grid-template-rows: repeat(@hoursPerDay, 1.5em);">
-		@{
-
-			if (DayDisplay)
-			{
-				<span class="grid" style="grid-column: 1;"></span>
-				for (int columnCounter = 2; columnCounter < 2 + DayCount; columnCounter++)
-				{
-				<span class="grid" style="grid-column: @columnCounter; text-align: center;">
-					@MyScheduleState.DisplayBeginDate.AddDays(columnCounter-2).ToString("ddd MMM d")
-				</span>
-				}
-			}
-
-			for (var i = 0; i < hoursPerDay; i++)
-			{
-				<span class="grid" style="grid-column: 1;">
-					<text>@currentTime.ToString("h:mm tt")</text>
-					@{ currentTime = currentTime.AddHours(1); }
-				</span>
-
-				for (int columnCounter = 2; columnCounter < 2 + DayCount; columnCounter++)
-				{
-					<span class="grid" style="grid-column: @columnCounter"></span>
-				}
-
-			}
-		}
-
-		@if (MyScheduleState != null)
+		if (Model.DayDisplay)
 		{
-			foreach (var item in MyScheduleState.TimeSlots.Where(s => s.StartDateTime.Date == SelectedDate.Date))
+			<span class="grid" style="grid-column: 1;"></span>
+			for (int columnCounter = 2; columnCounter < 2 + Model.DayCount; columnCounter++)
 			{
-				if (DisplayItem(item.StartDateTime, item.EndDateTime))
-				{
-					<span class="scheduleItem @ItemBorderStyle(item.StartDateTime, item.EndDateTime)" style="grid-row-start: @ItemStartRow(item.StartDateTime); top: @ItemTopPosition(item.StartDateTime); height: @ItemRowHeight(item.StartDateTime, item.EndDateTime);">
-						@item.Name  - @item.StartDateTime.ToShortTimeString()
-					</span>
-				}
+				<span class="grid" style="grid-column: @columnCounter; text-align: center;">
+					@Model.MyScheduleState.DisplayBeginDate.AddDays(columnCounter - 2).ToString("ddd MMM d")
+				</span>
 			}
 		}
 
-	</div>
+		var currentTime = Model.DayViewStart;
+
+		for (var i = 0; i < Model.HoursPerDay; i++)
+		{
+			<span class="grid" style="grid-column: 1;">
+				<text>@currentTime.ToString("h:mm tt")</text>
+				@{ currentTime = currentTime.AddHours(1); }
+			</span>
+
+			for (int columnCounter = 2; columnCounter < 2 + Model.DayCount; columnCounter++)
+			{
+				<span class="grid" style="grid-column: @columnCounter"></span>
+			}
+		}
+	}
+
+	@if (Model.MyScheduleState != null)
+	{
+		foreach (var item in Model.MyScheduleState.TimeSlots.Where(s => s.StartDateTime.Date == Model.SelectedDate.Date))
+		{
+			if (Model.DisplayItem(item.StartDateTime, item.EndDateTime))
+			{
+				<span class="scheduleItem @Model.ItemBorderStyle(item.StartDateTime, item.EndDateTime)" style="grid-row-start: @Model.ItemStartRow(item.StartDateTime); top: @Model.ItemTopPosition(item.StartDateTime); height: @Model.ItemRowHeight(item.StartDateTime, item.EndDateTime);">
+					@item.Name  - @item.StartDateTime.ToShortTimeString()
+				</span>
+			}
+		}
+	}
+
+</div>
 
 @code {
 
-	DateTime SelectedDate
-	{
-		get { return MyScheduleState?.SelectedDate ?? DateTime.Today; }
-	}
+	// TODO: Simon G - Work out if it is possible to make the Model a property with a Parameter attribute and pass the whole thing in from the parent rather than using DI, there may be a timing DI vs Paramater state being set, which might be offset by component composition.
 
-	Schedule MySchedule
-	{
-		get { return MyScheduleState.Schedule; }
-	}
-
-	// Cheer 701 themichaeljolley 09/07/19 
-	// Cheer 600 cpayette 09/07/19 
-	// Cheer 1500 clintonrocksmith 09/07/19 
+	// Cheer 701 themichaeljolley 09/07/19
+	// Cheer 600 cpayette 09/07/19
+	// Cheer 1500 clintonrocksmith 09/07/19
 
 	[Parameter]
-	Data.ScheduleState MyScheduleState { get; set; }
+	Data.ScheduleState MyScheduleState => Model.MyScheduleState;
 
 	[Parameter]
-	DateTime DayViewStart { get; set; } = DateTime.Today.AddHours(8);
+	DateTime DayViewStart => Model.DayViewStart;
 
 	[Parameter]
-	DateTime DayViewEnd { get; set; } = DateTime.Today.AddHours(20);
+	DateTime DayViewEnd => Model.DayViewEnd;
 
-	// Cheer 110 copperbeardy 14/07/19 
+	// Cheer 110 copperbeardy 14/07/19
 
 	[Parameter]
-	int DayCount { get; set; } = 1;
+	int DayCount => Model.DayCount;
 
-	/// <summary>
-	/// Should we display the dates above the grid
-	/// </summary>
 	[Parameter]
-	bool DayDisplay { get; set; } = false;
+	bool DayDisplay => Model.DayDisplay;
 
 	protected override void OnInit()
 	{
-
-		if (MyScheduleState != null)
+		if (Model.MyScheduleState != null)
 		{
-			MyScheduleState.OnSelectedDateChanged += (o, args) =>
-			{
-				Invoke(StateHasChanged);
-			};
+			Model.MyScheduleState.OnSelectedDateChanged += (o, args) => { Invoke(StateHasChanged); };
 		}
-
 		base.OnInit();
 	}
 
@@ -105,99 +83,5 @@
 	{
 		this.StateHasChanged();
 		base.OnParametersSet();
-	}
-
-	bool DisplayItem(DateTime start, DateTime end)
-	{
-
-		var startDayView = SelectedDate.Date.Add(DayViewStart.TimeOfDay);
-		var endDayView = SelectedDate.Date.Add(DayViewEnd.TimeOfDay);
-
-		if (start >= endDayView || end <= startDayView) { return false; }
-		return true;
-	}
-
-	string ItemBorderStyle(DateTime start, DateTime end)
-	{
-		string top = "starts-before";
-		string bottom = "ends-after";
-
-		var startDayView = SelectedDate.Date.Add(DayViewStart.TimeOfDay);
-		var endDayView = SelectedDate.Date.Add(DayViewEnd.TimeOfDay);
-
-		return String.Format("{0} {1}",
-			(start < startDayView) ? top : "",
-			(end > endDayView) ? bottom : "");
-	}
-
-	int ItemStartRow(DateTime start)
-	{
-		if (start.Hour <= DayViewStart.Hour)
-		{
-			return 1;
-		}
-
-		return (start.Hour - DayViewStart.Hour) + 1;
-	}
-
-	string ItemTopPosition(DateTime start)
-	{
-		double top = 0D;
-		var startDayView = SelectedDate.Date.Add(DayViewStart.TimeOfDay);
-
-		if (start < startDayView)
-		{
-			return "-0.050em";
-		}
-
-		if (start > startDayView && start.Minute > 0)
-		{
-			top = 0.025 * start.Minute;
-		}
-		return (top > 0) ? $"{top}em" : "0";
-	}
-
-	string ItemRowHeight(DateTime start, DateTime end)
-	{
-		double height = 0D;
-		double totalMinutes;
-
-		TimeSpan startTime;
-		TimeSpan endTime;
-		if (start.TimeOfDay < DayViewStart.TimeOfDay)
-		{
-			startTime = DayViewStart.TimeOfDay;
-		} else if (start.Date < SelectedDate)
-		{
-			startTime = DayViewStart.TimeOfDay;
-		} else
-		{
-			startTime = start.TimeOfDay;
-		}
-
-		if (end.TimeOfDay >= DayViewEnd.TimeOfDay)
-		{
-			endTime = DayViewEnd.TimeOfDay;
-		} else if (end.Date > SelectedDate)
-		{
-			endTime = DayViewEnd.TimeOfDay;
-		} else
-		{
-			endTime = end.TimeOfDay;
-		}
-
-		if (start.TimeOfDay < DayViewStart.TimeOfDay)
-		{
-			height += 0.050; // Add 2 extra minutes for negative top position from ItemTopPosition
-		}
-
-		totalMinutes = endTime.Subtract(startTime).TotalMinutes;
-		height += 0.025 * totalMinutes; // 1 minute = 1.25em / 60 = 0.025em
-
-		/* Adjust for row gaps, 1px = 0.063em at base 16px size 
-		 * according to http://pxtoem.com/ */
-		height += 0.063 * (endTime.Subtract(startTime).TotalHours);
-
-		return (height > 0) ? $"{height}em" : "0";
 	}
 }

--- a/src/Fritz.ResourceManagement.WebClient/Pages/ManagerScheduleView.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/ManagerScheduleView.razor
@@ -1,44 +1,24 @@
 <h3>Schedule View</h3>
-@inject Data.ScheduleState MyScheduleState
-@inject HttpClient  HttpClient
-
+@inject ViewModels.ManagerScheduleViewViewModel Model
 
 <div id="weekSelector">
-
-	<a href="" @onclick="() => ChangeDate(-7)">&lt;</a>
-	@MyScheduleState.DisplayBeginDate.ToShortDateString() - @MyScheduleState.DisplayEndDate.AddDays(-1).ToShortDateString()
-	<a href="" @onclick="() => ChangeDate(7)">&gt;</a>
+	@{ 
+		// TODO: Simon G - Do we really need the onclick="() => Model.ChangeDate(-7)" syntax ? Would this not work as onclick="Model.ChangeDate(-7)"?
+	}
+	<a href="" @onclick="() => Model.OnChangeDate(-7)">&lt;</a>
+	@Model.MyScheduleState.DisplayBeginDate.ToShortDateString() - @Model.MyScheduleState.DisplayEndDate.AddDays(-1).ToShortDateString()
+	<a href="" @onclick="() => Model.OnChangeDate(7)">&gt;</a>
 
 </div>
 
 <div id="MyScheduleContainer">
-	<DayView DayCount="7" DayDisplay="true" MyScheduleState="MyScheduleState"></DayView>
+	<DayView DayCount="7" DayDisplay="true" MyScheduleState="Model.MyScheduleState"></DayView>
 </div>
-
 
 @code {
 
 	[Parameter]
-	DateTime SelectedDate {
-		get { return MyScheduleState.SelectedDate; }
-		set { MyScheduleState.SelectDate(value); }
-	}
+	DateTime SelectedDate => Model.SelectedDate;
 
-	IEnumerable<Schedule> Schedules;
-
-	protected override async Task OnParametersSetAsync()
-	{
-
-		MyScheduleState.DisplayBeginDate = SelectedDate.Subtract(TimeSpan.FromDays((int)SelectedDate.DayOfWeek));
-		MyScheduleState.DisplayEndDate = MyScheduleState.DisplayBeginDate.AddDays(7);
-
-		Schedules = await HttpClient.GetJsonAsync<Schedule[]>($"schedule/forrange/{MyScheduleState.DisplayBeginDate.ToShortDateString()}/{MyScheduleState.DisplayEndDate.ToShortDateString()}");
-
-	}
-
-	void ChangeDate(int daysToChange)
-	{
-		SelectedDate = SelectedDate.AddDays(daysToChange);
-	}
-
+	protected override async Task OnParametersSetAsync() => await this.Model.InitializeAsync();
 }

--- a/src/Fritz.ResourceManagement.WebClient/Pages/ManagerScheduleView.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/ManagerScheduleView.razor
@@ -20,5 +20,5 @@
 	[Parameter]
 	DateTime SelectedDate => Model.SelectedDate;
 
-	protected override async Task OnParametersSetAsync() => await this.Model.InitializeAsync();
+	protected override async Task OnParametersSetAsync() => await this.Model.OnParametersSetAsync();
 }

--- a/src/Fritz.ResourceManagement.WebClient/Pages/RecurrenceDataEntry.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/RecurrenceDataEntry.razor
@@ -1,9 +1,9 @@
-@using Fritz.ResourceManagement.Domain
+@inject ViewModels.RecurrenceDataEntryViewModel Model
 
-<input class="form-control" type="text" name="Name" @bind="Schedule.Name" placeholder="Name of the Recurring Appointment" />
-<input class="form-control" type="date" name="StartDate" @bind="Schedule.MinStartDateTime" placeholder="Start Date" />
-<input class="form-control" type="date" name="EndDate" @bind="Schedule.MaxEndDateTime" placeholder="End Date" />
-<input class="form-control" type="time" name="StartTime" @bind="StartTime" placeholder="Start time" />
+<input class="form-control" type="text" name="Name" @bind="Model.Schedule.Name" placeholder="Name of the Recurring Appointment" />
+<input class="form-control" type="date" name="StartDate" @bind="Model.Schedule.MinStartDateTime" placeholder="Start Date" />
+<input class="form-control" type="date" name="EndDate" @bind="Model.Schedule.MaxEndDateTime" placeholder="End Date" />
+<input class="form-control" type="time" name="StartTime" @bind="Model.StartTime" placeholder="Start time" />
 
 <fieldset>
 
@@ -16,96 +16,44 @@
 		@*<option value="M">Monthly</option>*@
 	</select>
 
-	@if (Pattern == "W")
+	@if (Model.Pattern == "W")
 	{
+		// TODO: Simon G - Do we really need the onchange='() => Model.OnDOWChange("xx")' syntax ? Would this not work as onchange='Model.OnDOWChange("xx")'?
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="0" @onchange='() => DowChange("0")' /><label class="form-check-label" for="dow">Sunday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="0" @onchange='() => Model.OnDOWChange("0")' /><label class="form-check-label" for="dow">Sunday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="1" @onchange='() => DowChange("1")' /><label class="form-check-label" for="dow">Monday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="1" @onchange='() => Model.OnDOWChange("1")' /><label class="form-check-label" for="dow">Monday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="2" @onchange='() => DowChange("2")' /><label class="form-check-label" for="dow">Tuesday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="2" @onchange='() => Model.OnDOWChange("2")' /><label class="form-check-label" for="dow">Tuesday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="3" @onchange='() => DowChange("3")' /><label class="form-check-label" for="dow">Wednesday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="3" @onchange='() => Model.OnDOWChange("3")' /><label class="form-check-label" for="dow">Wednesday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="4" @onchange='() => DowChange("4")' /><label class="form-check-label" for="dow">Thursday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="4" @onchange='() => Model.OnDOWChange("4")' /><label class="form-check-label" for="dow">Thursday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="5" @onchange='() => DowChange("5")' /><label class="form-check-label" for="dow">Friday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="5" @onchange='() => Model.OnDOWChange("5")' /><label class="form-check-label" for="dow">Friday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="6" @onchange='() => DowChange("6")' /><label class="form-check-label" for="dow">Saturday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="6" @onchange='() => Model.OnDOWChange("6")' /><label class="form-check-label" for="dow">Saturday</label>
 		</div>
-			}
+	}
 
-	</fieldset>
+</fieldset>
 
-<input class="form-control" type="text" name="Duration" @bind="Schedule.DurationText" placeholder="Duration for each recurring item" />
-<button class="btn btn-primary" @onclick="Save">Add New Recurring Schedule</button>
+<input class="form-control" type="text" name="Duration" @bind="Model.Schedule.DurationText" placeholder="Duration for each recurring item" />
+<button class="btn btn-primary" @onclick="Model.Save">Add New Recurring Schedule</button>
 
 @code {
 
 	// Cheer 1000 cpayette 27/06/19 
 
 	[Parameter]
-	RecurringSchedule Schedule { get; set; }
+	RecurringSchedule Schedule => Model.Schedule;
 
 	[Parameter]
-	EventCallback OnSave { get; set; }
-
-	string Pattern { get; set; }
-
-	string StartTime { get; set; }
-
-	TimeSpan TimeOfDay {  get { return TimeSpan.Parse(StartTime); } }
-
-	HashSet<string> DaysOfTheWeek { get; set; } = new HashSet<string>();
-
-	void DowChange(string day)
-	{
-		if (DaysOfTheWeek.Contains(day))
-		{
-			DaysOfTheWeek.Remove(day);
-		} else {
-			DaysOfTheWeek.Add(day);
-		}
-	}
-
-	public string CalculatedCronPattern {
-		get
-		{
-
-			var sb = new System.Text.StringBuilder();
-			sb.Append($"{TimeOfDay.Minutes} ");
-
-			sb.Append($"{TimeOfDay.Hours} ");
-
-			sb.Append("* * ");
-
-			if (Pattern == "D" || !DaysOfTheWeek.Any())
-			{
-				sb.Append("*");
-			} else
-			{
-				sb.Append(string.Join(",", DaysOfTheWeek.ToArray()));
-			} 
-
-			return sb.ToString();
-		}
-	}
-
-	void Save()
-	{
-		if (OnSave.HasDelegate)
-		{
-
-			Schedule.CronPattern = CalculatedCronPattern;
-
-			OnSave.InvokeAsync(Schedule);
-		}
-	}
-
+	EventCallback OnSave => Model.OnSave;
 }

--- a/src/Fritz.ResourceManagement.WebClient/Pages/RecurrenceDataEntry.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Pages/RecurrenceDataEntry.razor
@@ -19,25 +19,25 @@
 	@if (Pattern == "W")
 	{
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="0" onchange="@(() => DowChange("0"))" /><label class="form-check-label" for="dow">Sunday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="0" @onchange='() => DowChange("0")' /><label class="form-check-label" for="dow">Sunday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="1" onchange="@(() => DowChange("1"))" /><label class="form-check-label" for="dow">Monday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="1" @onchange='() => DowChange("1")' /><label class="form-check-label" for="dow">Monday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="2" onchange="@(() => DowChange("2"))" /><label class="form-check-label" for="dow">Tuesday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="2" @onchange='() => DowChange("2")' /><label class="form-check-label" for="dow">Tuesday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="3" onchange="@(() => DowChange("3"))" /><label class="form-check-label" for="dow">Wednesday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="3" @onchange='() => DowChange("3")' /><label class="form-check-label" for="dow">Wednesday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="4" onchange="@(() => DowChange("4"))" /><label class="form-check-label" for="dow">Thursday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="4" @onchange='() => DowChange("4")' /><label class="form-check-label" for="dow">Thursday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="5" onchange="@(() => DowChange("5"))" /><label class="form-check-label" for="dow">Friday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="5" @onchange='() => DowChange("5")' /><label class="form-check-label" for="dow">Friday</label>
 		</div>
 		<div class="form-check">
-			<input type="checkbox" class="form-check-input" name="dow" value="6" onchange="@(() => DowChange("6"))" /><label class="form-check-label" for="dow">Saturday</label>
+			<input type="checkbox" class="form-check-input" name="dow" value="6" @onchange='() => DowChange("6")' /><label class="form-check-label" for="dow">Saturday</label>
 		</div>
 			}
 

--- a/src/Fritz.ResourceManagement.WebClient/Shared/NavMenu.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Shared/NavMenu.razor
@@ -1,29 +1,17 @@
-﻿<nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+﻿@inject ViewModels.NavMenuViewModel Model
+
+<nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
 	<div class="container">
 		<a class="navbar-brand" href="">Fritz.ResourceManagement.Web</a>
-		<button class="navbar-toggler" @onclick="ToggleNavMenu">
+		<button class="navbar-toggler" @onclick="Model.ToggleNavMenu">
 			<span class="navbar-toggler-icon"></span>
 		</button>
 		<div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
-			@** Login *@
 			<ul class="navbar-nav flex-grow-1">
 				<li class="nav-item">
 					<NavLink class="nav-link" href="" Match="NavLinkMatch.All">Home</NavLink>
 				</li>
 			</ul>
 		</div>
-
 	</div>
 </nav>
-
-
-@code {
-	bool collapseNavMenu = true;
-
-	string NavMenuCssClass => collapseNavMenu ? "collapse" : null;
-
-	void ToggleNavMenu()
-	{
-		collapseNavMenu = !collapseNavMenu;
-	}
-}

--- a/src/Fritz.ResourceManagement.WebClient/Startup.cs
+++ b/src/Fritz.ResourceManagement.WebClient/Startup.cs
@@ -7,12 +7,7 @@ namespace Fritz.ResourceManagement.WebClient
 	{
 		public void ConfigureServices(IServiceCollection services)
 		{
-			services.AddTransient<ViewModels.AvailabilityViewModel>();
-			services.AddTransient<ViewModels.DayPickerViewModel>();
-			services.AddTransient<ViewModels.DayViewViewModel>();
-		  services.AddTransient<ViewModels.ManagerScheduleViewViewModel>();
-		  services.AddTransient<ViewModels.NavMenuViewModel>();	  
-		  services.AddTransient<ViewModels.RecurrenceDataEntryViewModel>();	  
+			services.AddViewModels();
 		}
 
 		public void Configure(IComponentsApplicationBuilder app)

--- a/src/Fritz.ResourceManagement.WebClient/Startup.cs
+++ b/src/Fritz.ResourceManagement.WebClient/Startup.cs
@@ -1,17 +1,18 @@
-using Microsoft.AspNetCore.Components.Builder;
+﻿using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Fritz.ResourceManagement.WebClient
 {
-    public class Startup
-    {
-        public void ConfigureServices(IServiceCollection services)
-        {
-        }
+	public class Startup
+	{
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddTransient<ViewModels.AvailabilityViewModel>();
+		}
 
-        public void Configure(IComponentsApplicationBuilder app)
-        {
-            app.AddComponent<App>("app");
-        }
-    }
+		public void Configure(IComponentsApplicationBuilder app)
+		{
+			app.AddComponent<App>("app");
+		}
+	}
 }

--- a/src/Fritz.ResourceManagement.WebClient/Startup.cs
+++ b/src/Fritz.ResourceManagement.WebClient/Startup.cs
@@ -11,6 +11,7 @@ namespace Fritz.ResourceManagement.WebClient
 			services.AddTransient<ViewModels.DayPickerViewModel>();
 			services.AddTransient<ViewModels.DayViewViewModel>();
 		  services.AddTransient<ViewModels.ManagerScheduleViewViewModel>();
+		  services.AddTransient<ViewModels.NavMenuViewModel>();	  
 		  services.AddTransient<ViewModels.RecurrenceDataEntryViewModel>();	  
 		}
 

--- a/src/Fritz.ResourceManagement.WebClient/Startup.cs
+++ b/src/Fritz.ResourceManagement.WebClient/Startup.cs
@@ -8,6 +8,7 @@ namespace Fritz.ResourceManagement.WebClient
 		public void ConfigureServices(IServiceCollection services)
 		{
 			services.AddTransient<ViewModels.AvailabilityViewModel>();
+			services.AddTransient<ViewModels.DayPickerViewModel>();
 		}
 
 		public void Configure(IComponentsApplicationBuilder app)

--- a/src/Fritz.ResourceManagement.WebClient/Startup.cs
+++ b/src/Fritz.ResourceManagement.WebClient/Startup.cs
@@ -10,7 +10,8 @@ namespace Fritz.ResourceManagement.WebClient
 			services.AddTransient<ViewModels.AvailabilityViewModel>();
 			services.AddTransient<ViewModels.DayPickerViewModel>();
 			services.AddTransient<ViewModels.DayViewViewModel>();
-		  services.AddTransient<ViewModels.ManagerScheduleViewViewModel>();	  
+		  services.AddTransient<ViewModels.ManagerScheduleViewViewModel>();
+		  services.AddTransient<ViewModels.RecurrenceDataEntryViewModel>();	  
 		}
 
 		public void Configure(IComponentsApplicationBuilder app)

--- a/src/Fritz.ResourceManagement.WebClient/Startup.cs
+++ b/src/Fritz.ResourceManagement.WebClient/Startup.cs
@@ -9,6 +9,7 @@ namespace Fritz.ResourceManagement.WebClient
 		{
 			services.AddTransient<ViewModels.AvailabilityViewModel>();
 			services.AddTransient<ViewModels.DayPickerViewModel>();
+			services.AddTransient<ViewModels.DayViewViewModel>();
 		}
 
 		public void Configure(IComponentsApplicationBuilder app)

--- a/src/Fritz.ResourceManagement.WebClient/Startup.cs
+++ b/src/Fritz.ResourceManagement.WebClient/Startup.cs
@@ -10,6 +10,7 @@ namespace Fritz.ResourceManagement.WebClient
 			services.AddTransient<ViewModels.AvailabilityViewModel>();
 			services.AddTransient<ViewModels.DayPickerViewModel>();
 			services.AddTransient<ViewModels.DayViewViewModel>();
+		  services.AddTransient<ViewModels.ManagerScheduleViewViewModel>();	  
 		}
 
 		public void Configure(IComponentsApplicationBuilder app)

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/AvailabilityViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/AvailabilityViewModel.cs
@@ -15,6 +15,9 @@ namespace Fritz.ResourceManagement.WebClient.ViewModels
 		public RecurringSchedule NewRecurringSchedule { get; private set; }
 		public ScheduleState MyScheduleState { get; private set; }
 
+		public DateTime DayViewStart => DateTime.Today.AddHours(8);
+		public DateTime DayViewEnd => DateTime.Today.AddHours(20);
+
 		private Schedule MySchedule { get; set; } = null;
 		private DateTime SelectedDate { get; set; } = DateTime.Today;
 

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/AvailabilityViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/AvailabilityViewModel.cs
@@ -1,0 +1,96 @@
+﻿using Fritz.ResourceManagement.Domain;
+using Fritz.ResourceManagement.WebClient.Data;
+using Microsoft.AspNetCore.Components;
+using System;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Fritz.ResourceManagement.WebClient.ViewModels
+{
+	public class AvailabilityViewModel
+	{
+		public ClaimsPrincipal CurrentUser { get; private set; }
+		public ScheduleItem NewScheduleItem { get; private set; }
+		public RecurringSchedule NewRecurringSchedule { get; private set; }
+		public ScheduleState MyScheduleState { get; private set; }
+
+		private Schedule MySchedule { get; set; } = null;
+		private DateTime SelectedDate { get; set; } = DateTime.Today;
+
+		// TODO: Simon G - Do we still need this?
+		private DateTime ThisMonth { get { return new DateTime(SelectedDate.Year, SelectedDate.Month, 1); } }
+		
+		private readonly HttpClient httpClient;
+
+		public AvailabilityViewModel(
+			ClaimsPrincipal currentUser, 
+			ScheduleState myScheduleState,
+			HttpClient httpClient)
+		{
+			this.CurrentUser = currentUser;
+			this.MyScheduleState = myScheduleState;
+			this.httpClient = httpClient;
+		}
+
+		public async Task OnInitAsync()
+		{
+			this.ResetScheduleItem();
+			this.MySchedule = await GetMyAvailability();
+
+			this.MyScheduleState.SelectDate(SelectedDate);
+			this.MyScheduleState.Schedule = MySchedule;
+			this.MyScheduleState.ExpandSchedule();
+		}
+
+		public async Task AddNewRecurringSchedule()
+		{
+			// Cheer 2000 organicIT 23/06/19
+
+			this.NewRecurringSchedule.Status = ScheduleStatus.NotAvailable;
+			this.NewRecurringSchedule.ScheduleId = MySchedule.Id;
+			this.MySchedule.RecurringSchedules.Add(NewRecurringSchedule);
+
+			await this.httpClient.PutJsonAsync($"schedule/{MySchedule.Id}", MySchedule);
+
+			this.MyScheduleState.ScheduleUpdated();
+
+			this.ResetScheduleItem();
+		}
+
+		private async Task<Schedule> GetMyAvailability()
+		{
+			return await this.httpClient.GetJsonAsync<Schedule>($"schedule/{MyScheduleState.ScheduleId}");
+		}
+
+		public async Task AddNewScheduleItem()
+		{
+			// Cheer 200 ultramark 07/06/19
+			// Cheer 100 TheMichaelJolley 07/06/19
+
+			this.NewScheduleItem.Status = ScheduleStatus.NotAvailable;
+			this.NewScheduleItem.ScheduleId = MySchedule.Id;
+			this.MySchedule.ScheduleItems.Add(NewScheduleItem);
+
+			await this.httpClient.PutJsonAsync($"schedule/{MySchedule.Id}", MySchedule);
+
+			this.MyScheduleState.ScheduleUpdated();
+
+			this.ResetScheduleItem();
+		}
+
+		private void ResetScheduleItem()
+		{
+			this.NewScheduleItem = new ScheduleItem()
+			{
+			  StartDateTime = DateTime.Today,
+				EndDateTime = DateTime.Today.AddDays(1)
+			};
+			this.NewRecurringSchedule = new RecurringSchedule()
+			{
+			  MinStartDateTime = DateTime.Today,
+			  MaxEndDateTime = DateTime.Today.AddDays(7),
+			};
+		}
+	}
+}

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/DayPickerViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/DayPickerViewModel.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Fritz.ResourceManagement.Domain;
+using Fritz.ResourceManagement.WebClient.Data;
+
+namespace Fritz.ResourceManagement.WebClient.ViewModels
+{
+	public class DayPickerViewModel
+	{
+		public DateTime SelectedDate
+		{
+			get { return this.MyScheduleState.SelectedDate; }
+			set { this.MyScheduleState.SelectDate(value); }
+		}
+		public int FirstDayOfMonthDoW
+		{
+			get
+			{
+				var first = new DateTime(this.SelectedDate.Year, this.SelectedDate.Month, 1);
+				return (int)first.DayOfWeek;
+			}
+		}
+		
+		public int LastDayOfMonth
+		{
+			get
+			{
+				return new DateTime(this.SelectedDate.Year, this.SelectedDate.Month, 1).AddMonths(1).AddDays(-1).Day;
+			}
+		}
+		
+		public ScheduleState MyScheduleState { get; private set; }
+
+		// TODO: Simon G - I think this was dead code from the razor code block and can probably be removed.
+		public Schedule MySchedule
+		{
+			get { return this.MyScheduleState.Schedule; }
+		}
+
+		public DayPickerViewModel(ScheduleState myScheduleState)
+		{
+			this.MyScheduleState = myScheduleState;
+		}
+
+		public void GotoToday()
+		{
+			this.SelectedDate = DateTime.Today;
+		}
+
+		public void PrevMonth()
+		{
+			this.SelectedDate = this.SelectedDate.AddMonths(-1);
+			this.SelectedDate = new DateTime(this.SelectedDate.Year, this.SelectedDate.Month, 1);
+		}
+		public void NextMonth()
+		{
+			this.SelectedDate = this.SelectedDate.AddMonths(1);
+			this.SelectedDate = new DateTime(this.SelectedDate.Year, this.SelectedDate.Month, 1);
+		}
+	}
+}

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/DayPickerViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/DayPickerViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Fritz.ResourceManagement.Domain;
 using Fritz.ResourceManagement.WebClient.Data;
 
@@ -28,6 +29,21 @@ namespace Fritz.ResourceManagement.WebClient.ViewModels
 			}
 		}
 		
+		public DayOfMonthDisplayInfo DisplayDayOfMonth(int dayOfMonth)
+		{
+			var thisDay = new DateTime(this.SelectedDate.Year, this.SelectedDate.Month, dayOfMonth);
+			var today = (thisDay.Date == DateTime.Today.Date) ? "today" : null;
+
+			return new DayOfMonthDisplayInfo()
+			{
+				ThisDay = thisDay,
+				Today = today,
+				HasAppointment = this.MyScheduleState.TimeSlots.Any(x => x.StartDateTime.Date == thisDay.Date) ? "appt" : null,
+				IsSelected = (thisDay == this.SelectedDate) ? "active" : null,
+				Title = (string.IsNullOrEmpty(today)) ? null : "Today!"
+			};
+		}
+		
 		public ScheduleState MyScheduleState { get; private set; }
 
 		// TODO: Simon G - I think this was dead code from the razor code block and can probably be removed.
@@ -55,6 +71,15 @@ namespace Fritz.ResourceManagement.WebClient.ViewModels
 		{
 			this.SelectedDate = this.SelectedDate.AddMonths(1);
 			this.SelectedDate = new DateTime(this.SelectedDate.Year, this.SelectedDate.Month, 1);
+		}
+
+		public struct DayOfMonthDisplayInfo
+		{
+			public DateTime ThisDay;
+			public string Today;
+			public string HasAppointment;
+			public string IsSelected;
+			public string Title;
 		}
 	}
 }

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/DayViewViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/DayViewViewModel.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using Fritz.ResourceManagement.Domain;
+
+namespace Fritz.ResourceManagement.WebClient.ViewModels
+{
+	public class DayViewViewModel
+	{
+		public int HoursPerDay
+		{
+			get { return this.DayViewEnd.Subtract(this.DayViewStart).Hours; }
+		}
+
+	public DateTime SelectedDate
+		{
+			get { return this.MyScheduleState?.SelectedDate ?? DateTime.Today; }
+		}
+
+		public Schedule MySchedule
+		{
+			get { return this.MyScheduleState.Schedule; }
+		}
+
+		public Data.ScheduleState MyScheduleState { get; set; }
+		public DateTime DayViewStart { get; set; } = DateTime.Today.AddHours(8);
+		public DateTime DayViewEnd { get; set; } = DateTime.Today.AddHours(20);
+		public int DayCount { get; set; } = 1;
+
+		/// <summary>
+		/// Should we display the dates above the grid
+		/// </summary>
+		public bool DayDisplay { get; set; } = false;
+
+		public bool DisplayItem(DateTime start, DateTime end)
+		{
+			var startDayView = this.SelectedDate.Date.Add(this.DayViewStart.TimeOfDay);
+			var endDayView = this.SelectedDate.Date.Add(this.DayViewEnd.TimeOfDay);
+
+			if (start >= endDayView || end <= startDayView) { return false; }
+			return true;
+		}
+
+		public string ItemBorderStyle(DateTime start, DateTime end)
+		{
+			string top = "starts-before";
+			string bottom = "ends-after";
+
+			var startDayView = this.SelectedDate.Date.Add(this.DayViewStart.TimeOfDay);
+			var endDayView = this.SelectedDate.Date.Add(this.DayViewEnd.TimeOfDay);
+
+			return String.Format("{0} {1}",
+				(start < startDayView) ? top : "",
+				(end > endDayView) ? bottom : "");
+		}
+
+		public int ItemStartRow(DateTime start)
+		{
+			if (start.Hour <= this.DayViewStart.Hour)
+			{
+				return 1;
+			}
+
+			return (start.Hour - this.DayViewStart.Hour) + 1;
+		}
+
+		public string ItemTopPosition(DateTime start)
+		{
+			double top = 0D;
+			var startDayView = this.SelectedDate.Date.Add(this.DayViewStart.TimeOfDay);
+
+			if (start < startDayView)
+			{
+				return "-0.050em";
+			}
+
+			if (start > startDayView && start.Minute > 0)
+			{
+				top = 0.025 * start.Minute;
+			}
+			return (top > 0) ? $"{top}em" : "0";
+		}
+
+		public string ItemRowHeight(DateTime start, DateTime end)
+		{
+			double height = 0D;
+			double totalMinutes;
+
+			TimeSpan startTime;
+			TimeSpan endTime;
+			if (start.TimeOfDay < this.DayViewStart.TimeOfDay)
+			{
+				startTime = this.DayViewStart.TimeOfDay;
+			}
+			else if (start.Date < this.SelectedDate)
+			{
+				startTime = this.DayViewStart.TimeOfDay;
+			}
+			else
+			{
+				startTime = start.TimeOfDay;
+			}
+
+			if (end.TimeOfDay >= this.DayViewEnd.TimeOfDay)
+			{
+				endTime = this.DayViewEnd.TimeOfDay;
+			}
+			else if (end.Date > this.SelectedDate)
+			{
+				endTime = this.DayViewEnd.TimeOfDay;
+			}
+			else
+			{
+				endTime = end.TimeOfDay;
+			}
+
+			if (start.TimeOfDay < this.DayViewStart.TimeOfDay)
+			{
+				height += 0.050; // Add 2 extra minutes for negative top position from ItemTopPosition
+			}
+
+			totalMinutes = endTime.Subtract(startTime).TotalMinutes;
+			height += 0.025 * totalMinutes; // 1 minute = 1.25em / 60 = 0.025em
+
+			/* Adjust for row gaps, 1px = 0.063em at base 16px size
+			 * according to http://pxtoem.com/ */
+			height += 0.063 * (endTime.Subtract(startTime).TotalHours);
+
+			return (height > 0) ? $"{height}em" : "0";
+		}
+	}
+}

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/Extensions.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/Extensions.cs
@@ -1,0 +1,18 @@
+﻿using Fritz.ResourceManagement.WebClient.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Fritz.ResourceManagement.WebClient
+{
+	public static class Extensions
+	{
+		public static void AddViewModels(this IServiceCollection services)
+		{
+			services.AddTransient<AvailabilityViewModel>();
+			services.AddTransient<DayPickerViewModel>();
+			services.AddTransient<DayViewViewModel>();
+			services.AddTransient<ManagerScheduleViewViewModel>();
+			services.AddTransient<NavMenuViewModel>();
+			services.AddTransient<RecurrenceDataEntryViewModel>();
+		}
+	}
+}

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/ManagerScheduleViewViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/ManagerScheduleViewViewModel.cs
@@ -31,7 +31,7 @@ namespace Fritz.ResourceManagement.WebClient.ViewModels
 			this.SelectedDate = this.SelectedDate.AddDays(daysToChange);
 		}
 
-		public async Task InitializeAsync()
+		public async Task OnParametersSetAsync()
 		{
 			this.MyScheduleState.DisplayBeginDate = this.SelectedDate.Subtract(TimeSpan.FromDays((int)this.SelectedDate.DayOfWeek));
 			this.MyScheduleState.DisplayEndDate = this.MyScheduleState.DisplayBeginDate.AddDays(7);

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/ManagerScheduleViewViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/ManagerScheduleViewViewModel.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Fritz.ResourceManagement.Domain;
+using Fritz.ResourceManagement.WebClient.Data;
+using Microsoft.AspNetCore.Components;
+
+namespace Fritz.ResourceManagement.WebClient.ViewModels
+{
+	public class ManagerScheduleViewViewModel
+	{
+		public IEnumerable<Schedule> Schedules { get; private set; }
+		public DateTime SelectedDate
+		{
+			get { return this.MyScheduleState.SelectedDate; }
+			set { this.MyScheduleState.SelectDate(value); }
+		}
+		public ScheduleState MyScheduleState { get; private set; }
+
+		private readonly HttpClient HttpClient;
+
+		public ManagerScheduleViewViewModel(ScheduleState myScheduleState, HttpClient httpClient)
+		{
+			this.MyScheduleState = myScheduleState;
+			this.HttpClient = httpClient;
+		}
+
+		public void OnChangeDate(int daysToChange)
+		{
+			this.SelectedDate = this.SelectedDate.AddDays(daysToChange);
+		}
+
+		public async Task InitializeAsync()
+		{
+			this.MyScheduleState.DisplayBeginDate = this.SelectedDate.Subtract(TimeSpan.FromDays((int)this.SelectedDate.DayOfWeek));
+			this.MyScheduleState.DisplayEndDate = this.MyScheduleState.DisplayBeginDate.AddDays(7);
+
+			this.Schedules = await HttpClient.GetJsonAsync<Schedule[]>($"schedule/forrange/{this.MyScheduleState.DisplayBeginDate.ToShortDateString()}/{this.MyScheduleState.DisplayEndDate.ToShortDateString()}");
+		}
+	}
+}

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/NavMenuViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/NavMenuViewModel.cs
@@ -1,0 +1,14 @@
+﻿namespace Fritz.ResourceManagement.WebClient.ViewModels
+{
+	public class NavMenuViewModel
+	{
+		private bool collapseNavMenu { get; set; } = true;
+
+		public string NavMenuCssClass => this.collapseNavMenu ? "collapse" : null;
+
+		public void ToggleNavMenu()
+		{
+			this.collapseNavMenu = !this.collapseNavMenu;
+		}
+	}
+}

--- a/src/Fritz.ResourceManagement.WebClient/ViewModels/RecurrenceDataEntryViewModel.cs
+++ b/src/Fritz.ResourceManagement.WebClient/ViewModels/RecurrenceDataEntryViewModel.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Fritz.ResourceManagement.Domain;
+using Microsoft.AspNetCore.Components;
+
+namespace Fritz.ResourceManagement.WebClient.ViewModels
+{
+	public class RecurrenceDataEntryViewModel
+	{
+		public RecurringSchedule Schedule { get; set; }
+
+		public EventCallback OnSave { get; set; }
+
+		public string Pattern { get; set; }
+
+		public string StartTime { get; set; }
+
+		public TimeSpan TimeOfDay { get { return TimeSpan.Parse(this.StartTime); } }
+
+		public HashSet<string> DaysOfTheWeek { get; set; } = new HashSet<string>();
+
+
+		public void OnDOWChange(string day)
+		{
+			if (this.DaysOfTheWeek.Contains(day))
+			{
+				this.DaysOfTheWeek.Remove(day);
+			}
+			else
+			{
+				this.DaysOfTheWeek.Add(day);
+			}
+		}
+
+		public void Save()
+		{
+			if (this.OnSave.HasDelegate)
+			{
+				this.Schedule.CronPattern = this.CalculatedCronPattern();
+
+				this.OnSave.InvokeAsync(this.Schedule);
+			}
+		}
+
+		private string CalculatedCronPattern()
+		{
+			var sb = new System.Text.StringBuilder();
+
+			sb.Append($"{this.TimeOfDay.Minutes} ");
+			sb.Append($"{this.TimeOfDay.Hours} ");
+			sb.Append("* * ");
+
+			if (this.Pattern == "D" || !this.DaysOfTheWeek.Any())
+			{
+				sb.Append("*");
+			}
+			else
+			{
+				sb.Append(string.Join(",", this.DaysOfTheWeek.ToArray()));
+			}
+			return sb.ToString();
+		}
+	}
+}


### PR DESCRIPTION
This PR is to refactored all code blocks the Blazor views out into corresponding ViewModel classes to improve separation of presentation markup from presentation logic. 

**NOTE: I was unable to get the app running due to URL routing/nav issues**

As such the limit of dev testing for this PR amounts to:
1. A build of the solution after each refactoring. 
2. Running of existing unit tests
3. Running solution to the main page and checking for client-side errors

I would recommend that this is thoroughly reviewed before being merged, preferably by pilling this branch locally so it can be loaded/debugged. 

**Details of changes**
View models have been placed in a ViewModel folder in the main Fritz.ResourceManagement.WebClient project. Should we subsequently find that this causes problems with the need to reference this from the Unit Test project we have the option to extract the ViewModel classes into their own .Net Standard Lib. 

I have added "//TODO: Simon G - " task comments to areas of note where there are options for further improvement or refactoring, or where I have questions or concerns about how the code might work in a ViewModel. 

The registration of ViewModels in DI has been pulled out into an extension method to help segregate ViewModel DI as a sperate distinct set of registrations. I have not extracted interfaces for DI as I don't believe it is currently required, this may change if testing of UI collaborations becomes complex.

**Thoughts on further enhancements** 
There are two main areas where code is left in the Blazor Code blocks:

1. Overrides to Blazor protected ComponentBase members
  It may be preferable to also move this code out of the markup. If this is the case then it should be possible to derive the component from a [CodeBehind base class](https://docs.microsoft.com/en-us/aspnet/core/blazor/components?view=aspnetcore-3.0#base-class-inheritance-for-a-code-behind-experience) as noted in the Blazor documentation which would still allow the DI of the Model 
2. [Component Parameter properties](https://docs.microsoft.com/en-us/aspnet/core/blazor/components?view=aspnetcore-3.0#component-parameters) - [param] properties
  I have attempted to delegate the param properties to the corresponding VM members. It may be preferable to review each usage of pram properties to see if passing the full ViewModel of the component in as param rather than injecting it would be more desirable.
