### PR TITLE
Fixed formatting Header bar in WebClient

### DIFF
--- a/src/Fritz.ResourceManagement.WebClient/Fritz.ResourceManagement.WebClient.csproj
+++ b/src/Fritz.ResourceManagement.WebClient/Fritz.ResourceManagement.WebClient.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BlazorStrap" Version="1.0.0-preview7-01" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview7.19365.7" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview7.19365.7" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.DevServer" Version="3.0.0-preview7.19365.7" PrivateAssets="all" />

--- a/src/Fritz.ResourceManagement.WebClient/Shared/MainLayout.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Shared/MainLayout.razor
@@ -5,9 +5,9 @@
 </header>
 
 <div class="main">
-    <div class="top-row px-4">
+    @*<div class="top-row px-4">
         <a href="http://blazor.net" target="_blank" class="ml-md-auto">About</a>
-    </div>
+    </div>*@
 
     <div class="content px-4">
         @Body

--- a/src/Fritz.ResourceManagement.WebClient/Shared/NavMenu.razor
+++ b/src/Fritz.ResourceManagement.WebClient/Shared/NavMenu.razor
@@ -1,29 +1,50 @@
-﻿<nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+﻿<BSNavbar IsDark="false" Color="Color.Light" Class="navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
 	<div class="container">
-		<a class="navbar-brand" href="">Fritz.ResourceManagement.Web</a>
-		<button class="navbar-toggler" @onclick="ToggleNavMenu">
+		<BSNavbarBrand Href="#">Fritz.ResourceManagement.Web</BSNavbarBrand>
+		<BSNavbarToggler onclick="onclick" />
+		<BSCollapse isOpen="@IsOpen" IsNavbar="true">
+			<BSNav IsList="true" Class="mr-auto" IsNavbar="true">
+				<BSNavItem>
+					<BSNavLink IsActive="true" Href="#">Home</BSNavLink>
+				</BSNavItem>
+			</BSNav>
+		</BSCollapse>
+	</div>
+</BSNavbar>
+
+@*<nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+	<div class="container">
+		<a class="navbar-brand" href="">fritz.resourcemanagement.web</a>
+		<button class="navbar-toggler" @onclick="togglenavmenu">
 			<span class="navbar-toggler-icon"></span>
 		</button>
 		<div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
-			@** Login *@
+			* login 
 			<ul class="navbar-nav flex-grow-1">
 				<li class="nav-item">
-					<NavLink class="nav-link" href="" Match="NavLinkMatch.All">Home</NavLink>
+					<navlink class="nav-link text-dark" href="" match="navlinkmatch.all">home</navlink>
 				</li>
 			</ul>
 		</div>
 
 	</div>
-</nav>
+</nav>*@
 
 
 @code {
-	bool collapseNavMenu = true;
+	//bool collapseNavMenu = true;
 
-	string NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+	//string NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
-	void ToggleNavMenu()
+	//void ToggleNavMenu()
+	//{
+	//	collapseNavMenu = !collapseNavMenu;
+	//}
+
+	bool IsOpen { get; set; } = false;
+	void onclick(UIMouseEventArgs e)
 	{
-		collapseNavMenu = !collapseNavMenu;
+		IsOpen = !IsOpen;
+		StateHasChanged();
 	}
 }

--- a/src/Fritz.ResourceManagement.WebClient/_Imports.razor
+++ b/src/Fritz.ResourceManagement.WebClient/_Imports.razor
@@ -5,3 +5,4 @@
 @using Microsoft.JSInterop
 @using Fritz.ResourceManagement.WebClient
 @using Fritz.ResourceManagement.WebClient.Shared
+@using BlazorStrap

--- a/src/Fritz.ResourceManagement.WebClient/wwwroot/css/site.css
+++ b/src/Fritz.ResourceManagement.WebClient/wwwroot/css/site.css
@@ -5,9 +5,14 @@ html, body {
 }
 
 app {
-    position: relative;
-    display: flex;
-    flex-direction: column;
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex-wrap: wrap;
+}
+
+header {
+	flex: 1 100%;
 }
 
 .top-row {
@@ -44,7 +49,7 @@ app {
         top: -2px;
     }
 
-.nav-item {
+/*.nav-item {
     font-size: 0.9rem;
     padding-bottom: 0.5rem;
 }
@@ -74,7 +79,7 @@ app {
         .nav-item a:hover {
             background-color: rgba(255,255,255,0.1);
             color: white;
-        }
+        }*/
 
 .content {
     padding-top: 1.1rem;


### PR DESCRIPTION
Here's the fix for issue #51

I commented all the code we had previously in case we need it in the future. For example, if we use NavLink in the future then we can uncomment the CSS and change the class to use the formatting included with the site.css.

Hopefully, this helps us get the formatting for the app going smoothly.